### PR TITLE
fix: use camelCase options for PayPalScriptProvider

### DIFF
--- a/components/PayPalPaymentModal.tsx
+++ b/components/PayPalPaymentModal.tsx
@@ -182,11 +182,11 @@ export default function PayPalPaymentModal({
 
         <PayPalScriptProvider
           options={{
-            "client-id": config.clientId,
+            clientId: config.clientId,
             currency: config.currency,
             intent: "capture",
             components: "buttons",
-            "disable-funding": "venmo,paylater",
+            disableFunding: "venmo,paylater",
           }}
         >
           <PayPalButtonsInner


### PR DESCRIPTION
PayPal SDK v9 ReactPayPalScriptOptions requires clientId and disableFunding (camelCase). Kebab-case keys caused Vercel TS build failure.